### PR TITLE
Clear search filter when setting a keyword filter

### DIFF
--- a/srfi.el
+++ b/srfi.el
@@ -231,6 +231,7 @@
                       "Narrow SRFIs to keyword: " srfi-data-keywords
                       nil t nil nil (list nil))))
   (setq srfi-narrow-keyword keyword)
+  (setq srfi-narrow-query "")
   (srfi-list))
 
 (defun srfi-dired ()


### PR DESCRIPTION
This makes it so if you first narrow to the search string `list` then narrow to the keyword `R7RS Large`, the `list` filter is cleared. In the current `master` version, the old `list` filter is kept together with the `R7RS Large` keyword filter, resulting in a combination of the two.

It's still possible to add back the search filter after setting a keyword filter.

@arthurgleckler What do you think about this behavior? I find it slightly less confusing than the old one. Most of the time if I look for a keyword, I find that the keyword is unrelated to any search I had going on previously.